### PR TITLE
download binary to /tmp,  sudo to install

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,9 +9,9 @@ runs:
   steps:
   - run: curl -O "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
     shell: bash
-  - run: bash ./install_kustomize.sh ${{ inputs.kustomize-version }}
+  - run: bash ./install_kustomize.sh ${{ inputs.kustomize-version }} /tmp
     shell: bash
-  - run: mv kustomize /usr/local/bin/kustomize && chmod +x /usr/local/bin/kustomize
+  - run: sudo mv /tmp/kustomize /usr/local/bin/kustomize && chmod +x /usr/local/bin/kustomize
     shell: bash
   - run: rm -f ./install_kustomize.sh
     shell: bash


### PR DESCRIPTION
Sometimes there's a `kustomize` directory in source, which the upstream script will complain about, then exit with failure. I've updated this to download the binary to /tmp.

My runner doesn't run as root, so I've added `sudo` to the `mv` statement.

None of this should break existing usage.